### PR TITLE
Better API for getting annotation properties

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/processor/src/main/java/com/kevinmost/auto/value/defensive_copy/processor/DefensiveCopyExtension.kt
+++ b/processor/src/main/java/com/kevinmost/auto/value/defensive_copy/processor/DefensiveCopyExtension.kt
@@ -31,7 +31,6 @@ import javax.lang.model.element.Modifier.PRIVATE
 import javax.lang.model.element.Modifier.PROTECTED
 import javax.lang.model.element.Modifier.PUBLIC
 import javax.lang.model.element.Modifier.STATIC
-import javax.lang.model.type.TypeMirror
 
 open class DefensiveCopyExtension : AutoValueExtension() {
 
@@ -65,7 +64,7 @@ sealed class DefensivelyCopiedProperty(protected val context: Context, protected
   companion object {
     fun from(context: Context, property: AutoValueProperty): DefensivelyCopiedProperty {
       val copyAnnotation = property[DefensiveCopy::class]!!
-      val copierName: TypeName = (copyAnnotation["copier"] as TypeMirror).asTypeName
+      val copierName = copyAnnotation[DefensiveCopy::copier]
       return when (copierName) {
         DefensiveCopier::class.asTypeName -> DefaultDefensiveCopier(context, property)
         else -> CustomDefensiveCopier(context, property, copierName)

--- a/processor/src/main/java/com/kevinmost/auto/value/defensive_copy/processor/util/AutoValueUtil.kt
+++ b/processor/src/main/java/com/kevinmost/auto/value/defensive_copy/processor/util/AutoValueUtil.kt
@@ -10,7 +10,7 @@ val Context.generateSuperclassConstructor: MethodSpec
             name = it.name,
             type = it.returnType,
             annotations = it.annotations
-                .filter { it.isNullityAnnotation }
+                .filter { it.annotationType.simpleName() in listOf("NotNull", "NonNull", "Nullable") }
                 .map { buildAnnotation(it.annotationType) }
         )
       }


### PR DESCRIPTION
Hides the weirdness of Class<?> properties from AnnotationMirrors
coming back as TypeMirrors, by changing them to TypeNames before
returning